### PR TITLE
Price representation fix

### DIFF
--- a/src/main/java/net/dandielo/citizens/trader/commands/core/TraderCommands.java
+++ b/src/main/java/net/dandielo/citizens/trader/commands/core/TraderCommands.java
@@ -1,6 +1,7 @@
 package net.dandielo.citizens.trader.commands.core;
 
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.util.List;
 import java.util.Map;
 
@@ -370,7 +371,8 @@ public class TraderCommands {
 		CitizensTrader.getPatternsManager().reload();
 	}
 	
-	private static DecimalFormat format = new DecimalFormat("#.##");
+	private static NumberFormat format = NumberFormat.getCurrencyInstance();
+	//private static DecimalFormat format = new DecimalFormat("#.##");
 	
 	@Command(
 	name = "trader",
@@ -415,8 +417,8 @@ public class TraderCommands {
 		if ( CitizensTrader.getEconomy().withdrawPlayer(sender.getName(), amount).transactionSuccess() )
 		{
 			wallet.deposit(null, amount);
-			locale.sendMessage(sender, "wallet-deposit", "amount", format.format(amount));
-			locale.sendMessage(sender, "wallet-balance", "amount", format.format(wallet.getMoney()));
+			locale.sendMessage(sender, "wallet-deposit", "amount", format.format(amount).replace("$", ""));
+			locale.sendMessage(sender, "wallet-balance", "amount", format.format(wallet.getMoney()).replace("$", ""));
 		}
 		else
 			locale.sendMessage(sender, "wallet-deposit-fail");
@@ -436,8 +438,8 @@ public class TraderCommands {
 		if ( wallet.withdraw(null, amount) )
 		{
 			CitizensTrader.getEconomy().depositPlayer(sender.getName(), amount);
-			locale.sendMessage(sender, "wallet-withdraw", "amount", format.format(amount));
-			locale.sendMessage(sender, "wallet-balance", "amount", format.format(wallet.getMoney()));
+			locale.sendMessage(sender, "wallet-withdraw", "amount", format.format(amount).replace("$", ""));
+			locale.sendMessage(sender, "wallet-balance", "amount", format.format(wallet.getMoney()).replace("$", ""));
 		}
 		else
 			locale.sendMessage(sender, "wallet-withdraw-fail");
@@ -454,7 +456,7 @@ public class TraderCommands {
 		if ( !wallet.getType().equals(WalletType.NPC) )
 			locale.sendMessage(sender, "wallet-invalid");
 		else
-			locale.sendMessage(sender, "wallet-balance", "amount", format.format(wallet.getMoney()));
+			locale.sendMessage(sender, "wallet-balance", "amount", format.format(wallet.getMoney()).replace("$", ""));
 	}
 	
 }

--- a/src/main/java/net/dandielo/citizens/trader/denizen/TraderTags.java
+++ b/src/main/java/net/dandielo/citizens/trader/denizen/TraderTags.java
@@ -1,6 +1,7 @@
 package net.dandielo.citizens.trader.denizen;
 
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -134,7 +135,7 @@ public class TraderTags implements Listener {
         	if ( tag.equals("wallet") )
         	{
         		if ( subtag.equals("balance") )
-        			e.setReplaced(new DecimalFormat("#.##").format(trader.getConfig().getWallet().getMoney()));
+        			e.setReplaced(NumberFormat.getCurrencyInstance().format(trader.getConfig().getWallet().getMoney()).replace("$", ""));
         		else 
         			e.setReplaced(trader.getConfig().getWallet().getType().toString());
         	}
@@ -207,7 +208,7 @@ public class TraderTags implements Listener {
         List<StockItem> stock = trader.getStock().getStock(st);
         for ( StockItem item : stock )
         {
-        	String price = new DecimalFormat("#.##").format(trader.getStock().getPrice(item, p, st, 0));
+        	String price = NumberFormat.getCurrencyInstance().format(trader.getStock().getPrice(item, p, st, 0)).replace("$", "");
         	hint += " | " + hintItem.replaceAll("\\{price\\}", price).replaceAll("\\{name\\}", item.name());
         }
 		return hint.isEmpty() ? "empty stock" : hint.substring(3);

--- a/src/main/java/net/dandielo/citizens/trader/objects/StockItem.java
+++ b/src/main/java/net/dandielo/citizens/trader/objects/StockItem.java
@@ -1,6 +1,7 @@
 package net.dandielo.citizens.trader.objects;
 
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -442,7 +443,7 @@ public class StockItem {
 		
 		//saving the item price
 		if ( !patternPrice && hasPrice )
-			itemString += " p:" + new DecimalFormat("#.##").format(price);
+			itemString += " p:" + NumberFormat.getCurrencyInstance().format(price).replace("$", "");
 		
 		//saving the item slot
 		itemString += " s:" + slot;

--- a/src/main/java/net/dandielo/citizens/trader/parts/TraderStockPart.java
+++ b/src/main/java/net/dandielo/citizens/trader/parts/TraderStockPart.java
@@ -1,6 +1,7 @@
 package net.dandielo.citizens.trader.parts;
 
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -526,9 +527,10 @@ public class TraderStockPart implements InventoryHolder {
 	public static List<String> getPriceLore(StockItem item, int slot, String stock, Map<Integer, TPattern> patterns, Player player)
 	{
 		String price = "";
-		DecimalFormat format = new DecimalFormat("#.##");
+		NumberFormat format = NumberFormat.getCurrencyInstance();
+		//DecimalFormat format = new DecimalFormat("#.##");
 
-		price = format.format(TraderStockPart.getPrice(item, patterns, player, stock, slot));
+		price = format.format(TraderStockPart.getPrice(item, patterns, player, stock, slot)).replace("$", "");
 		
 		List<String> lore = new ArrayList<String>();
 		for ( String line : CitizensTrader.getLocaleManager().lore("trader-inventory-" + stock) )//itemsConfig.getPriceLore(stock) )
@@ -540,9 +542,10 @@ public class TraderStockPart implements InventoryHolder {
 	public static List<String> getManagePriceLore(StockItem item, int slot, String stock, Map<Integer, TPattern> patterns, Player player)
 	{
 		String price = "";
-		DecimalFormat format = new DecimalFormat("#.##");
+		NumberFormat format = NumberFormat.getCurrencyInstance();
+		//DecimalFormat format = new DecimalFormat("#.##");
 
-		price = format.format(TraderStockPart.getPrice(item, patterns, player, stock, slot));
+		price = format.format(TraderStockPart.getPrice(item, patterns, player, stock, slot)).replace("$", "");
 		
 		List<String> lore = new ArrayList<String>();
 		for ( String line : CitizensTrader.getLocaleManager().lore("trader-inventory-buy") )//itemsConfig.getPriceLore(stock) )

--- a/src/main/java/net/dandielo/citizens/trader/types/MarketTrader.java
+++ b/src/main/java/net/dandielo/citizens/trader/types/MarketTrader.java
@@ -1,6 +1,7 @@
 package net.dandielo.citizens.trader.types;
 
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -33,7 +34,8 @@ public class MarketTrader extends Trader {
 	@Override
 	public void simpleMode(InventoryClickEvent event) 
 	{
-		DecimalFormat f = new DecimalFormat("#.##");
+	    NumberFormat f2 = NumberFormat.getCurrencyInstance();
+		//DecimalFormat f = new DecimalFormat("#.##");
 		
 	//	Player p = (Player) event.getWhoClicked();
 		int slot = event.getSlot();
@@ -133,7 +135,7 @@ public class MarketTrader extends Trader {
 						}
 						else
 						{
-							locale.sendMessage(player, "trader-transaction-success", "action", "#bought", "amount", String.valueOf(getSelectedItem().getAmount()), "price", f.format(price));
+							locale.sendMessage(player, "trader-transaction-success", "action", "#bought", "amount", String.valueOf(getSelectedItem().getAmount()), "price", f2.format(price).replace("$", ""));
 						
 
 							addSelectedToInventory(0);
@@ -184,7 +186,7 @@ public class MarketTrader extends Trader {
 					}
 					else
 					{
-						locale.sendMessage(player, "trader-transaction-success", "action", "#bought", "amount", String.valueOf(getSelectedItem().getAmount()), "price", f.format(price));
+						locale.sendMessage(player, "trader-transaction-success", "action", "#bought", "amount", String.valueOf(getSelectedItem().getAmount()), "price", f2.format(price).replace("$", ""));
 						
 						addSelectedToInventory(slot);
 
@@ -230,7 +232,7 @@ public class MarketTrader extends Trader {
 					}
 					else
 					{
-						locale.sendMessage(player, "trader-transaction-success", "action", "#sold", "amount", String.valueOf(getSelectedItem().getAmount()), "price", f.format(price));
+						locale.sendMessage(player, "trader-transaction-success", "action", "#sold", "amount", String.valueOf(getSelectedItem().getAmount()), "price", f2.format(price).replace("$", ""));
 					
 
 						removeFromInventory(event.getCurrentItem(),event);
@@ -276,7 +278,7 @@ public class MarketTrader extends Trader {
 				}
 				else
 				{
-					locale.sendMessage(player, "trader-transaction-success", "action", "#sold", "amount", String.valueOf(getSelectedItem().getAmount()), "price", f.format(price));
+					locale.sendMessage(player, "trader-transaction-success", "action", "#sold", "amount", String.valueOf(getSelectedItem().getAmount()), "price", f2.format(price).replace("$", ""));
 				
 					updateBuyLimits(scale);
 					removeFromInventory(event.getCurrentItem(),event);

--- a/src/main/java/net/dandielo/citizens/trader/types/MoneyBanker.java
+++ b/src/main/java/net/dandielo/citizens/trader/types/MoneyBanker.java
@@ -1,6 +1,7 @@
 package net.dandielo.citizens.trader.types;
 
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -57,7 +58,8 @@ public class MoneyBanker extends Banker {
 		Player player = (Player) event.getWhoClicked();
 		String playerName = (String) event.getWhoClicked().getName();
 		
-		DecimalFormat decimalFormat = new DecimalFormat("#.##");
+		NumberFormat decimalFormat = NumberFormat.getCurrencyInstance();
+		//DecimalFormat decimalFormat = new DecimalFormat("#.##");
 		int slot = event.getSlot();
 		
 		if ( slot < 0 )
@@ -88,7 +90,7 @@ public class MoneyBanker extends Banker {
 					double withdraw = current.getAmount()*itemValue;
 					economy.withdrawPlayer(playerName, withdraw);
 					locale.sendMessage(player, "banker-got-item", "name", current.getType().name(), "amount", current.getAmount());
-					locale.sendMessage(player, "banker-lost-money", "money", decimalFormat.format(withdraw));
+					locale.sendMessage(player, "banker-lost-money", "money", decimalFormat.format(withdraw).replace("$", ""));
 				//	player.sendMessage( locale.getLocaleString("mbank-xxx-item", "entity:player", "action:{transaction}", "transaction:bought").replace("{item}", current.getType().name()).replace("{amount}", ""+ current.getAmount()) );
 				//	player.sendMessage( locale.getLocaleString("xxx-money-xxx", "entity:player", "action:paid").replace("{money}", decimalFormat.format(withdraw)) );
 				}
@@ -111,7 +113,7 @@ public class MoneyBanker extends Banker {
 						
 					economy.withdrawPlayer(playerName, withdraw);
 					locale.sendMessage(player, "banker-item-got", "name", current.getType().name(), "amount", current.getAmount());
-					locale.sendMessage(player, "banker-money-lost", "money", decimalFormat.format(withdraw));
+					locale.sendMessage(player, "banker-money-lost", "money", decimalFormat.format(withdraw).replace("$", ""));
 				//	player.sendMessage( locale.getLocaleString("mbank-xxx-item", "entity:player", "action:{transaction}", "transaction:bought").replace("{item}", current.getType().name()).replace("{amount}", ""+ amount) );
 				//	player.sendMessage( locale.getLocaleString("xxx-money-xxx", "entity:player", "action:paid").replace("{money}", decimalFormat.format(withdraw)) );
 				}
@@ -203,7 +205,7 @@ public class MoneyBanker extends Banker {
 	public static void setDescription(ItemStack item, int amount)
 	{
 		List<String> lore = new ArrayList<String>();
-		lore.add("^r^7Value: ^6" + new DecimalFormat("#.##").format(amount * itemValue));
+		lore.add("^r^7Value: ^6" + NumberFormat.getCurrencyInstance().format(amount * itemValue).replace("$", ""));
 		NBTTagEditor.addDescription(item, lore);
 	}
 

--- a/src/main/java/net/dandielo/citizens/trader/types/PlayerTrader.java
+++ b/src/main/java/net/dandielo/citizens/trader/types/PlayerTrader.java
@@ -1,6 +1,7 @@
 package net.dandielo.citizens.trader.types;
 
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -29,7 +30,8 @@ public class PlayerTrader extends Trader {
 	@Override
 	public void simpleMode(InventoryClickEvent event) 
 	{
-		DecimalFormat f = new DecimalFormat("#.##");
+		NumberFormat f = NumberFormat.getCurrencyInstance();
+	    //DecimalFormat f = new DecimalFormat("#.##");
 		int slot = event.getSlot();
 		
 		if ( slot < 0 )
@@ -130,7 +132,7 @@ public class PlayerTrader extends Trader {
 						}
 						else
 						{
-							locale.sendMessage(player, "trader-transaction-success", "action", "#bought", "amount", String.valueOf(getSelectedItem().getAmount()), "price", f.format(price));
+							locale.sendMessage(player, "trader-transaction-success", "action", "#bought", "amount", String.valueOf(getSelectedItem().getAmount()), "price", f.format(price).replace("$", ""));
 						//	player.sendMessage( localeManager.getLocaleString("xxx-transaction-xxx-item", "entity:player", "transaction:bought").replace("{amount}", "" + getSelectedItem().getAmount() ).replace("{price}", f.format(getSelectedItem().getPrice()) ) );
 
 
@@ -329,7 +331,8 @@ public class PlayerTrader extends Trader {
 
 		boolean top = event.getView().convertSlot(event.getRawSlot()) == event.getRawSlot();
 		//Player p = (Player) event.getWhoClicked();
-		DecimalFormat f = new DecimalFormat("#.##");
+		NumberFormat f = NumberFormat.getCurrencyInstance();
+		//DecimalFormat f = new DecimalFormat("#.##");
 		
 		int clickedSlot = event.getSlot();
 		
@@ -660,7 +663,7 @@ public class PlayerTrader extends Trader {
 						
 						//select the item to get the information from, and show the price
 						if ( selectItem(event.getSlot(), getBasicManageModeByWool()).hasSelectedItem() ) 
-							locale.sendMessage(player, "key-value", "key", "#price", "value", f.format(getSelectedItem().getRawPrice()));
+							locale.sendMessage(player, "key-value", "key", "#price", "value", f.format(getSelectedItem().getRawPrice()).replace("$", ""));
 						
 						
 					} 
@@ -684,7 +687,7 @@ public class PlayerTrader extends Trader {
 							
 							
 							//show the new price
-							locale.sendMessage(player, "key-change", "key", "#price", "value", f.format(getSelectedItem().getRawPrice()));
+							locale.sendMessage(player, "key-change", "key", "#price", "value", f.format(getSelectedItem().getRawPrice()).replace("$", ""));
 							
 							
 						}

--- a/src/main/java/net/dandielo/citizens/trader/types/PrivateBanker.java
+++ b/src/main/java/net/dandielo/citizens/trader/types/PrivateBanker.java
@@ -1,6 +1,7 @@
 package net.dandielo.citizens.trader.types;
 
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
 
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
@@ -31,7 +32,8 @@ public class PrivateBanker extends Banker {
 		event.setCancelled(true);
 		
 		Player player = (Player) event.getWhoClicked();
-		DecimalFormat decimalFormat = new DecimalFormat("#.##");
+		NumberFormat decimalFormat = NumberFormat.getCurrencyInstance();
+		//DecimalFormat decimalFormat = new DecimalFormat("#.##");
 		int slot = event.getSlot();
 		
 		boolean top = event.getView().convertSlot(event.getRawSlot()) == event.getRawSlot();
@@ -53,7 +55,7 @@ public class PrivateBanker extends Banker {
 					{
 						if ( lastSlot != slot )
 						{
-							locale.sendMessage(player, "key-value", "key", "#tab-price", "value", decimalFormat.format(BankerPart.getTabPrice(tabs())));
+							locale.sendMessage(player, "key-value", "key", "#tab-price", "value", decimalFormat.format(BankerPart.getTabPrice(tabs())).replace("$", ""));
 						//	player.sendMessage( locale.getLocaleString("tab-price").replace("{value}", decimalFormat.format(BankerPart.getTabPrice(tabs()))) );
 
 							lastSlot = slot;

--- a/src/main/java/net/dandielo/citizens/trader/types/ServerTrader.java
+++ b/src/main/java/net/dandielo/citizens/trader/types/ServerTrader.java
@@ -1,6 +1,7 @@
 package net.dandielo.citizens.trader.types;
 
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -36,7 +37,8 @@ public class ServerTrader extends Trader {
 	@Override
 	public void simpleMode(InventoryClickEvent event) 
 	{
-		DecimalFormat f = new DecimalFormat("#.##");
+		NumberFormat f = NumberFormat.getCurrencyInstance();
+	    //DecimalFormat f = new DecimalFormat("#.##");
 		int slot = event.getSlot();
 		
 		if ( slot < 0 )
@@ -125,7 +127,7 @@ public class ServerTrader extends Trader {
 						}
 						else
 						{ 
-							locale.sendMessage(player, "trader-transaction-success", "action", "#bought", "amount", String.valueOf(getSelectedItem().getAmount()), "price", f.format(price));
+							locale.sendMessage(player, "trader-transaction-success", "action", "#bought", "amount", String.valueOf(getSelectedItem().getAmount()), "price", f.format(price).replace("$", ""));
 						
 							addSelectedToInventory(0);
 
@@ -310,7 +312,8 @@ public class ServerTrader extends Trader {
 			return;
 		}
 		
-		DecimalFormat f = new DecimalFormat("#.##");
+		NumberFormat f = NumberFormat.getCurrencyInstance();
+		//DecimalFormat f = new DecimalFormat("#.##");
 		
 		if ( top )
 		{
@@ -714,7 +717,7 @@ public class ServerTrader extends Trader {
 
 							//select item
 							if ( selectItem(slot, getBasicManageModeByWool()).hasSelectedItem() ) 
-								locale.sendMessage(player, "key-value", "key", "#price", "value", f.format(getSelectedItem().getRawPrice()));
+								locale.sendMessage(player, "key-value", "key", "#price", "value", f.format(getSelectedItem().getRawPrice()).replace("$", ""));
 							
 						} 
 						else
@@ -736,7 +739,7 @@ public class ServerTrader extends Trader {
 								NBTTagEditor.removeDescription(event.getCurrentItem());
 								event.setCurrentItem(TraderStockPart.setLore(event.getCurrentItem(), TraderStockPart.getPriceLore(getSelectedItem(), 0, getBasicManageModeByWool().toString(), getStock().getPatterns(), player)));
 
-								locale.sendMessage(player, "key-change", "key", "#price", "value", f.format(getSelectedItem().getRawPrice()));
+								locale.sendMessage(player, "key-change", "key", "#price", "value", f.format(getSelectedItem().getRawPrice()).replace("$", ""));
 							}
 							
 						}

--- a/src/main/java/net/dandielo/citizens/trader/types/Trader.java
+++ b/src/main/java/net/dandielo/citizens/trader/types/Trader.java
@@ -2,6 +2,7 @@ package net.dandielo.citizens.trader.types;
 
 import java.text.DateFormat;
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -309,11 +310,12 @@ public abstract class Trader implements tNPC {
 		{
 			int scale = is.getAmount() / it.getAmount();
 			
-			DecimalFormat f = new DecimalFormat("#.##");
+			NumberFormat f = NumberFormat.getCurrencyInstance();
+			//DecimalFormat f = new DecimalFormat("#.##");
 			
 			List<String> lore = new ArrayList<String>(); ;
 			for ( String l : CitizensTrader.getLocaleManager().lore("player-inventory") ) //itemsConfig.getPriceLore("pbuy") )
-				lore.add(l.replace("{unit}", f.format(getPrice(player, "buy"))+"").replace("{stack}", f.format(getPrice(player, "buy")*scale)+""));
+				lore.add(l.replace("{unit}", f.format(getPrice(player, "buy")).replace("$", "")+"").replace("{stack}", f.format(getPrice(player, "buy")*scale)+""));
 			
 			if ( scale > 0 )
 				NBTTagEditor.addDescription(is, lore);	
@@ -617,9 +619,10 @@ public abstract class Trader implements tNPC {
 		Date date = new Date();
 		DateFormat df = new SimpleDateFormat("HH-mm-ss");
 		
-		DecimalFormat dec = new DecimalFormat("#.##");
+		NumberFormat dec = NumberFormat.getCurrencyInstance();
+		//DecimalFormat dec = new DecimalFormat("#.##");
 		
-		loggingManager.log("["+df.format(date)+"]["+npc.getName()+"]["+action+"] - <" + player.getName() + ">\n      id:"+ id + " data:" + data + " amount:" + amount + " price:" + dec.format(price) );
+		loggingManager.log("["+df.format(date)+"]["+npc.getName()+"]["+action+"] - <" + player.getName() + ">\n      id:"+ id + " data:" + data + " amount:" + amount + " price:" + dec.format(price).format("$", "") );
 	}
 	
 	public void playerLog(String owner, String buyer, String action, StockItem item, int slot)
@@ -688,7 +691,8 @@ public abstract class Trader implements tNPC {
 	
 	public void loadDescriptions(Player player, Inventory inventory)
 	{
-		DecimalFormat f = new DecimalFormat("#.##");
+		NumberFormat f = NumberFormat.getCurrencyInstance();
+	    //DecimalFormat f = new DecimalFormat("#.##");
 		for ( int i = 0 ; i < inventory.getSize() ; ++i )
 		{
 			ItemStack item = inventory.getItem(i);
@@ -704,7 +708,7 @@ public abstract class Trader implements tNPC {
 
 					List<String> lore = new ArrayList<String>(); ;
 					for ( String l : CitizensTrader.getLocaleManager().lore("player-inventory") )
-						lore.add(l.replace("{unit}", f.format(getPrice(player, "buy", stockItem, 0))+"").replace("{stack}", f.format(getPrice(player, "buy", stockItem, 0)*scale)+""));
+						lore.add(l.replace("{unit}", f.format(getPrice(player, "buy", stockItem, 0)).replace("$", "")+"").replace("{stack}", f.format(getPrice(player, "buy", stockItem, 0)*scale).replace("$", "")+""));
 					
 					if ( scale > 0 )
 						NBTTagEditor.addDescription(item, lore);			


### PR DESCRIPTION
Prices where the decimal is a power of 10 (Examples: 1.10, 1.20 ect..) use to show as 1.1 or 1.2. This pull request fixes that and now shows them properly using the NumberFormat class.

**Added**
- N/A

**Removed**
- N/A

**Fixed**
- Prices sometimes showing wrong when the decimal is a power of 10.

**Tested?**
I sadly couldn't test this in a minecraft server because the maven script can't find dtlWallets. However, I did test what NumberFormat _should_ print out in a basic console program. Since this is such a small change, I don't think it would break anything, however I could be wrong about that.
